### PR TITLE
Add SSL/HTTPS configuration for pastoors.cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# SSL Certificates (sensitive - keep local only)
+ssl-bundle/
+*.zip
+
+# Build outputs
+frontend/dist/
+backend/target/
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Environment
+.env
+.env.local

--- a/backend/src/main/java/com/recipebook/config/SecurityConfig.java
+++ b/backend/src/main/java/com/recipebook/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("*"));
+        configuration.setAllowedOrigins(List.of("https://pastoors.cloud"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -43,6 +43,13 @@ services:
       - recipebook_default
     ports:
       - "80:80"
+      - "443:443"
+    volumes:
+      # SSL certificates - manually upload to server first
+      # Create folder /opt/ssl/pastoors.cloud/ on server and upload:
+      # - domain.cert.pem
+      # - private.key.pem
+      - /opt/ssl/pastoors.cloud:/etc/ssl/certs:ro
     depends_on:
       - backend
     restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx-ssl.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx-ssl.conf
+++ b/frontend/nginx-ssl.conf
@@ -1,0 +1,43 @@
+# HTTP -> HTTPS Redirect
+server {
+    listen 80;
+    server_name pastoors.cloud www.pastoors.cloud;
+
+    return 301 https://$host$request_uri;
+}
+
+# HTTPS Server
+server {
+    listen 443 ssl http2;
+    server_name pastoors.cloud www.pastoors.cloud;
+
+    # SSL Zertifikate (Porkbun)
+    ssl_certificate /etc/ssl/certs/domain.cert.pem;
+    ssl_certificate_key /etc/ssl/certs/private.key.pem;
+
+    # SSL Einstellungen (modern)
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    # www -> non-www Redirect
+    if ($host = www.pastoors.cloud) {
+        return 301 https://pastoors.cloud$request_uri;
+    }
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://recipebook-backend:8080/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- Add SSL configuration for pastoors.cloud
- Configure nginx for HTTPS with SSL certificates
- Add CORS configuration for HTTPS domain
- Create .gitignore for SSL certificates