### PR TITLE
feat: add vite proxy for local backend development

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,5 +8,13 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
+  },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      }
+    }
   }
 })


### PR DESCRIPTION
## Summary
- Add Vite proxy configuration to forward API requests to backend during local development
- Enables seamless frontend-backend integration without CORS issues on localhost