### PR TITLE
Backend tests & nginx MIME type fix

### DIFF
--- a/frontend/nginx-ssl.conf
+++ b/frontend/nginx-ssl.conf
@@ -29,6 +29,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    types {
+        application/javascript js mjs;
+        text/css css;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    types {
+        application/javascript js mjs;
+        text/css css;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary
- Add JwtServiceTest (7 unit tests) and RecipeServiceTest (16 unit tests)
- Fix hardcoded JWT secret in tests (now uses random UUID)
- Add explicit MIME types for JS files in nginx config to fix MIME type blocking issue

## Changes
- `backend/src/test/java/com/recipebook/service/JwtServiceTest.java`
- `backend/src/test/java/com/recipebook/service/RecipeServiceTest.java`
- `frontend/nginx-ssl.conf`
- `frontend/nginx.conf`

## Testing
- All 23 unit tests passing
- Local dev server works correctly