### PR TITLE
feat: Mehrere Bilder für Rezeptscan (Issue #17)

### DIFF
--- a/backend/src/main/java/com/recipebook/controller/RecipeScanController.java
+++ b/backend/src/main/java/com/recipebook/controller/RecipeScanController.java
@@ -4,6 +4,7 @@ import com.recipebook.service.RecipeScanService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -17,16 +18,19 @@ public class RecipeScanController {
   }
 
   @PostMapping
-  public ResponseEntity<?> scanRecipe(@RequestBody Map<String, String> request) {
-    String base64Image = request.get("imageData");
-    String mimeType = request.getOrDefault("mimeType", "image/jpeg");
+  public ResponseEntity<?> scanRecipe(@RequestBody List<Map<String, String>> images) {
+    if (images == null || images.isEmpty()) {
+      return ResponseEntity.badRequest().body(Map.of("error", "Mindestens ein Bild ist erforderlich"));
+    }
 
-    if (base64Image == null || base64Image.isBlank()) {
-      return ResponseEntity.badRequest().body(Map.of("error", "imageData ist erforderlich"));
+    for (Map<String, String> image : images) {
+      if (image.get("imageData") == null || image.get("imageData").isBlank()) {
+        return ResponseEntity.badRequest().body(Map.of("error", "imageData ist erforderlich"));
+      }
     }
 
     try {
-      RecipeScanService.RecipeScanResult result = recipeScanService.scanImage(base64Image, mimeType);
+      RecipeScanService.RecipeScanResult result = recipeScanService.scanImages(images);
       return ResponseEntity.ok(result);
     } catch (Exception e) {
       return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));

--- a/frontend/src/services/recipeService.js
+++ b/frontend/src/services/recipeService.js
@@ -106,7 +106,7 @@ class RecipeService {
     }
   }
 
-  async scanRecipe(imageData, mimeType) {
+  async scanRecipe(images) {
     try {
       const response = await fetch(`${API_BASE_URL}/recipes/scan`, {
         method: 'POST',
@@ -114,7 +114,7 @@ class RecipeService {
           'Content-Type': 'application/json',
           ...getAuthHeaders()
         },
-        body: JSON.stringify({ imageData, mimeType })
+        body: JSON.stringify(images)
       })
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`)


### PR DESCRIPTION
## Summary

Closes #17

- Nutzer können jetzt mehrere Rezeptfotos auswählen (z.B. mehrere Seiten eines Rezepts)
- Thumbnails der ausgewählten Bilder werden mit je einem Entfernen-Button angezeigt
- Analyse startet erst nach Klick auf den „Analysieren"-Button
- Alle Bilder werden in einem einzigen GPT-4.1 Call verarbeitet — das Modell fasst die Informationen über alle Seiten selbst zusammen

## Changes

**Backend**
- `RecipeScanService.java`: `scanImage()` → `scanImages(List<Map<String,String>>)`, baut mehrere `image_url`-Blöcke in einem OpenAI-Request
- `RecipeScanController.java`: Request-Body von `Map<String,String>` auf `List<Map<String,String>>` umgestellt

**Frontend**
- `recipeService.js`: `scanRecipe(imageData, mimeType)` → `scanRecipe(images[])` — sendet Array
- `RecipeForm.vue`: Neuer State `selectedImages[]`, Multi-File-Input, Thumbnail-Liste, „Analysieren"-Button