### PR TITLE
fix: increase WebClient buffer limit to 10MB for OpenAI responses

### DIFF
--- a/backend/src/main/java/com/recipebook/service/RecipeScanService.java
+++ b/backend/src/main/java/com/recipebook/service/RecipeScanService.java
@@ -22,6 +22,7 @@ public class RecipeScanService {
   public RecipeScanService(ObjectMapper objectMapper) {
     this.webClient = WebClient.builder()
       .baseUrl("https://api.openai.com")
+      .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(10 * 1024 * 1024))
       .build();
     this.objectMapper = objectMapper;
   }


### PR DESCRIPTION
## Problem

Der Spring `WebClient` hat standardmäßig ein In-Memory-Buffer-Limit von **256 KB** für Responses. Große OpenAI-Antworten (langer `rawText`, viele Zutaten/Schritte) überschreiten dieses Limit und werfen eine `DataBufferLimitException` — die im Frontend als generische Fehlermeldung „Das Rezeptbild konnte nicht analysiert werden" angezeigt wird.

## Fix

Buffer-Limit im `WebClient` auf **10 MB** erhöht. Das ist großzügig genug für jede realistische OpenAI-Response.

## Änderung

`RecipeScanService.java`: Eine Zeile in der `WebClient`-Konfiguration.