### PR TITLE
fix: Code Review Korrekturen (User Management)

### DIFF
--- a/backend/src/main/java/com/recipebook/service/AuthService.java
+++ b/backend/src/main/java/com/recipebook/service/AuthService.java
@@ -8,7 +8,6 @@ import com.recipebook.model.Role;
 import com.recipebook.model.User;
 import com.recipebook.repository.PasswordResetTokenRepository;
 import com.recipebook.repository.UserRepository;
-import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -155,10 +154,10 @@ public class AuthService {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Benutzer wurde nicht gefunden."));
 
-        if (request.getVorname() != null) {
+        if (request.getVorname() != null && !request.getVorname().isBlank()) {
             user.setVorname(request.getVorname());
         }
-        if (request.getNachname() != null) {
+        if (request.getNachname() != null && !request.getNachname().isBlank()) {
             user.setNachname(request.getNachname());
         }
         if (request.getEmail() != null && !request.getEmail().isBlank()) {
@@ -238,9 +237,11 @@ public class AuthService {
 
     private void sendPasswordResetEmail(String email, String token) {
         String link = appUrl + "/reset-password?token=" + token;
-        String text = "um dein Passwort zurueckzusetzen, klicke auf folgenden Link:\n\n"
+        String text = "Hallo,\n\n"
+                + "du hast ein Zuruecksetzen deines Passworts angefordert.\n"
+                + "Klicke bitte auf folgenden Link, um ein neues Passwort zu setzen:\n\n"
                 + link + "\n\n"
-                + "Du hast 1 Stunde Zeit, um dein Passwort zurueckzusetzen.\n\n"
+                + "Der Link ist 1 Stunde gueltig.\n\n"
                 + "Falls du diese Anfrage nicht gestellt hast, kannst du diese E-Mail ignorieren.\n\n"
                 + "Herzliche Gruesse\n"
                 + "Dein RecipeBook Team";
@@ -257,7 +258,7 @@ public class AuthService {
             helper.setSubject(subject);
             helper.setText(text, false);
             mailSender.send(message);
-        } catch (MessagingException e) {
+        } catch (Exception e) {
             System.err.println("Failed to send email to " + to + ": " + e.getMessage());
         }
     }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,8 +33,8 @@ services:
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       APP_URL: https://pastoors.cloud
       ALLOWED_ORIGIN: https://pastoors.cloud
-      SPRING_MAIL_HOST: smtp.mail.de
-      SPRING_MAIL_PORT: 587
+      SPRING_MAIL_HOST: ${MAIL_HOST}
+      SPRING_MAIL_PORT: ${MAIL_PORT}
       SPRING_MAIL_USERNAME: ${MAIL_USERNAME}
       SPRING_MAIL_PASSWORD: ${MAIL_PASSWORD}
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: "true"

--- a/frontend/src/components/ProfileModal.vue
+++ b/frontend/src/components/ProfileModal.vue
@@ -127,7 +127,7 @@ async function handleSubmit() {
     await authStore.updateProfile(payload)
     emit('close')
   } catch (err) {
-    error.value = 'Fehler beim Speichern. Bitte versuche es erneut.'
+    error.value = err.message || 'Fehler beim Speichern. Bitte versuche es erneut.'
   } finally {
     loading.value = false
   }


### PR DESCRIPTION
## Summary

Fixes aus dem Code Review von PR #27 die versehentlich auf dem bereits gemergten Branch committed wurden.

- `sendMail()`: `catch (Exception e)` statt `catch (MessagingException e)` — fängt jetzt auch `MailSendException` ab wenn der SMTP-Server nicht erreichbar ist
- `updateUser()`: `isBlank()`-Check fuer `vorname`/`nachname` — verhindert leere Strings in der DB
- `ProfileModal.vue`: zeigt jetzt die Server-Fehlermeldung (`err.message`) statt immer den generischen Fallback-Text
- Reset-Mail: Begruessung hinzugefuegt ("Hallo,")
- `docker-compose.prod.yml`: `MAIL_HOST` und `MAIL_PORT` als Env-Variablen statt hardcoded