### PR TITLE
feat: Changelog-Seite mit Updatehistorie (Issue #34)

### DIFF
--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -10,6 +10,10 @@
           Benutzer
         </router-link>
 
+        <router-link v-if="isAuthenticated" to="/changelog" class="navbar__link">
+          Updates
+        </router-link>
+
         <router-link v-if="showSearch && isAuthenticated" to="/recipe/new" class="navbar__btn navbar__btn--primary">
           Rezept hinzufügen
         </router-link>

--- a/frontend/src/data/changelog.js
+++ b/frontend/src/data/changelog.js
@@ -1,0 +1,67 @@
+export const changelog = [
+  {
+    date: '27.02.2026',
+    title: 'Nährwerte',
+    changes: [
+      'Automatische Nährwertberechnung via KI beim Anlegen und Bearbeiten von Rezepten',
+      'Nährwerttabelle in der Rezeptansicht mit Werten pro Portion und gesamt',
+      'Tabelle passt sich dynamisch an die gewählte Personenanzahl an',
+    ]
+  },
+  {
+    date: '25.02.2026',
+    title: 'Automatische Rezeptbilder',
+    changes: [
+      'Beim Anlegen eines Rezepts ohne eigenes Bild wird automatisch ein passendes Foto geladen',
+    ]
+  },
+  {
+    date: '25.02.2026',
+    title: 'Benutzerverwaltung',
+    changes: [
+      'Admins können Benutzer anlegen, bearbeiten und löschen',
+      'Benutzer können ihr Profil (Name, E-Mail, Passwort) selbst bearbeiten',
+      'Passwort-Reset per E-Mail',
+      'Neue Benutzer müssen ihr Passwort beim ersten Login ändern',
+    ]
+  },
+  {
+    date: '24.02.2026',
+    title: 'Rezepterfassung per Foto',
+    changes: [
+      'Rezepte können aus Fotos per KI automatisch erfasst werden',
+      'Mehrere Bilder gleichzeitig für den Rezeptscan hochladbar',
+      'Zubereitungszeit wird beim Scan erkannt und gespeichert',
+    ]
+  },
+  {
+    date: '24.02.2026',
+    title: 'Verbesserungen beim Rezept anlegen',
+    changes: [
+      'Zubereitungszeit (Minuten) kann angegeben werden',
+      'Personenanzahl als Bereich (z.B. 4–6 Personen) möglich',
+      'Einheiten-Autocomplete schlägt bekannte Einheiten vor',
+      'Neue unbekannte Einheiten können direkt hinzugefügt werden',
+    ]
+  },
+  {
+    date: '23.02.2026',
+    title: 'HTTPS & SSL',
+    changes: [
+      'Die Seite ist nun über https://pastoors.cloud erreichbar',
+      'Automatische Weiterleitung von HTTP auf HTTPS',
+    ]
+  },
+  {
+    date: '22.02.2026',
+    title: 'Start',
+    changes: [
+      'Rezepte anlegen, bearbeiten und löschen',
+      'Rezeptsuche nach Titel und Beschreibung',
+      'Zutaten mit Menge und Einheit',
+      'Zubereitungsschritte',
+      'Portionsrechner in der Rezeptansicht',
+      'Bild-Upload für Rezepte',
+    ]
+  },
+]

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -46,6 +46,12 @@ const router = createRouter({
       name: 'recipe-edit',
       component: () => import('@/views/RecipeEdit.vue'),
       meta: { requiresAuth: true }
+    },
+    {
+      path: '/changelog',
+      name: 'changelog',
+      component: () => import('@/views/ChangelogView.vue'),
+      meta: { requiresAuth: true }
     }
   ]
 })

--- a/frontend/src/views/ChangelogView.vue
+++ b/frontend/src/views/ChangelogView.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="changelog">
+    <h1>Updates</h1>
+    <div class="changelog-list">
+      <div v-for="(entry, index) in changelog" :key="index" class="changelog-entry">
+        <div class="changelog-header">
+          <h2 class="changelog-title">{{ entry.title }}</h2>
+          <span class="changelog-date">{{ entry.date }}</span>
+        </div>
+        <ul class="changelog-changes">
+          <li v-for="(change, i) in entry.changes" :key="i">{{ change }}</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { changelog } from '@/data/changelog'
+</script>
+
+<style scoped>
+.changelog {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.changelog h1 {
+  font-size: 2rem;
+  color: var(--color-text-primary, #333);
+  margin-bottom: 32px;
+}
+
+.changelog-list {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.changelog-entry {
+  background: var(--color-bg-card, #fff);
+  border-radius: 8px;
+  padding: 20px 24px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.changelog-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid var(--color-border, #ddd);
+}
+
+.changelog-title {
+  font-size: 1.25rem;
+  color: var(--color-text-primary, #333);
+  margin: 0;
+}
+
+.changelog-date {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #666);
+  white-space: nowrap;
+}
+
+.changelog-changes {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.changelog-changes li {
+  color: var(--color-text-primary, #333);
+  line-height: 1.5;
+}
+
+.changelog-changes li::marker {
+  color: var(--color-primary, #4a5568);
+}
+</style>


### PR DESCRIPTION
## Summary

- Neue Seite `/changelog` zeigt alle bisherigen Updates chronologisch (neueste zuerst)
- Statische Datei `src/data/changelog.js` für einfache manuelle Pflege bei neuen Releases
- "Updates"-Link in der NavBar für alle eingeloggten Nutzer sichtbar
- Alle bisherigen Updates seit dem Start (22.02.2026) dokumentiert

Closes #34