### PR TITLE
fix: Performance-Optimierung der Rezept-Übersichtsseite (#50)

### DIFF
--- a/backend/src/main/java/com/recipebook/controller/RecipeController.java
+++ b/backend/src/main/java/com/recipebook/controller/RecipeController.java
@@ -1,5 +1,6 @@
 package com.recipebook.controller;
 
+import com.recipebook.dto.RecipeSummaryDto;
 import com.recipebook.model.CustomUserDetails;
 import com.recipebook.model.Recipe;
 import com.recipebook.model.Role;
@@ -21,8 +22,8 @@ public class RecipeController {
     }
 
     @GetMapping
-    public List<Recipe> getAllRecipes() {
-        return recipeService.findAll();
+    public List<RecipeSummaryDto> getAllRecipes() {
+        return recipeService.findAllSummaries();
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/recipebook/dto/RecipeSummaryDto.java
+++ b/backend/src/main/java/com/recipebook/dto/RecipeSummaryDto.java
@@ -1,0 +1,42 @@
+package com.recipebook.dto;
+
+public class RecipeSummaryDto {
+
+  private Long id;
+  private String title;
+  private String description;
+  private String imageUrl;
+  private Integer prepTimeMinutes;
+  private Integer baseServings;
+  private Integer servingsTo;
+  private Long ingredientCount;
+
+  public RecipeSummaryDto(Long id, String title, String description, String imageUrl,
+      Integer prepTimeMinutes, Integer baseServings, Integer servingsTo, Long ingredientCount) {
+    this.id = id;
+    this.title = title;
+    this.description = description;
+    this.imageUrl = imageUrl;
+    this.prepTimeMinutes = prepTimeMinutes;
+    this.baseServings = baseServings;
+    this.servingsTo = servingsTo;
+    this.ingredientCount = ingredientCount;
+  }
+
+  public Long getId() { return id; }
+  public void setId(Long id) { this.id = id; }
+  public String getTitle() { return title; }
+  public void setTitle(String title) { this.title = title; }
+  public String getDescription() { return description; }
+  public void setDescription(String description) { this.description = description; }
+  public String getImageUrl() { return imageUrl; }
+  public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
+  public Integer getPrepTimeMinutes() { return prepTimeMinutes; }
+  public void setPrepTimeMinutes(Integer prepTimeMinutes) { this.prepTimeMinutes = prepTimeMinutes; }
+  public Integer getBaseServings() { return baseServings; }
+  public void setBaseServings(Integer baseServings) { this.baseServings = baseServings; }
+  public Integer getServingsTo() { return servingsTo; }
+  public void setServingsTo(Integer servingsTo) { this.servingsTo = servingsTo; }
+  public Long getIngredientCount() { return ingredientCount; }
+  public void setIngredientCount(Long ingredientCount) { this.ingredientCount = ingredientCount; }
+}

--- a/backend/src/main/java/com/recipebook/repository/RecipeRepository.java
+++ b/backend/src/main/java/com/recipebook/repository/RecipeRepository.java
@@ -1,5 +1,6 @@
 package com.recipebook.repository;
 
+import com.recipebook.dto.RecipeSummaryDto;
 import com.recipebook.model.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -7,7 +8,14 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
-    
-    @Query("SELECT r FROM Recipe r WHERE LOWER(r.title) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(r.description) LIKE LOWER(CONCAT('%', :query, '%'))")
-    List<Recipe> searchByTitleOrDescription(@Param("query") String query);
+
+  @Query("SELECT new com.recipebook.dto.RecipeSummaryDto(" +
+      "r.id, r.title, r.description, r.imageUrl, " +
+      "r.prepTimeMinutes, r.baseServings, r.servingsTo, " +
+      "(SELECT COUNT(i) FROM Ingredient i WHERE i.recipe = r)" +
+      ") FROM Recipe r ORDER BY r.id DESC")
+  List<RecipeSummaryDto> findAllSummaries();
+
+  @Query("SELECT r FROM Recipe r WHERE LOWER(r.title) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(r.description) LIKE LOWER(CONCAT('%', :query, '%'))")
+  List<Recipe> searchByTitleOrDescription(@Param("query") String query);
 }

--- a/backend/src/main/java/com/recipebook/service/RecipeService.java
+++ b/backend/src/main/java/com/recipebook/service/RecipeService.java
@@ -1,5 +1,6 @@
 package com.recipebook.service;
 
+import com.recipebook.dto.RecipeSummaryDto;
 import com.recipebook.model.CustomUserDetails;
 import com.recipebook.model.Recipe;
 import com.recipebook.model.Ingredient;
@@ -26,6 +27,10 @@ public class RecipeService {
         this.nutritionService = nutritionService;
     }
     
+    public List<RecipeSummaryDto> findAllSummaries() {
+        return recipeRepository.findAllSummaries();
+    }
+
     public List<Recipe> findAll() {
         return recipeRepository.findAll();
     }

--- a/frontend/src/components/RecipeCard.vue
+++ b/frontend/src/components/RecipeCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="recipe-card" @click="navigateToDetail">
     <div class="recipe-card__image">
-      <img :src="recipe.imageUrl || getFoodImage(recipe.id)" :alt="recipe.title" />
+      <img :src="recipe.imageUrl || getFoodImage(recipe.id)" :alt="recipe.title" loading="lazy" />
     </div>
     <div class="recipe-card__content">
       <h3 class="recipe-card__title">{{ recipe.title }}</h3>
@@ -10,11 +10,8 @@
         <span v-if="recipe.prepTimeMinutes" class="recipe-card__count">
           {{ formatPrepTime(recipe.prepTimeMinutes) }}
         </span>
-        <span v-if="recipe.ingredients" class="recipe-card__count">
-          {{ recipe.ingredients.length }} Zutaten
-        </span>
-        <span v-if="recipe.instructions" class="recipe-card__count">
-          {{ recipe.instructions.length }} Schritte
+        <span v-if="recipe.ingredientCount" class="recipe-card__count">
+          {{ recipe.ingredientCount }} Zutaten
         </span>
       </div>
     </div>

--- a/frontend/src/data/changelog.js
+++ b/frontend/src/data/changelog.js
@@ -1,6 +1,16 @@
 export const changelog = [
   {
     date: '28.02.2026',
+    title: 'Schnelleres Laden der Übersicht',
+    changes: [
+      'Die Übersichtsseite lädt deutlich schneller, weil jetzt nur noch die für die Karten benötigten Daten übertragen werden',
+      'Bilder werden erst geladen, wenn sie auf dem Bildschirm sichtbar werden — nicht alle auf einmal',
+      'Wechselt man zwischen Seiten hin und her, werden die Rezepte nicht unnötig neu geladen',
+      'Kehrt man zur App zurück (z.B. nach dem Wechsel in eine andere App), werden die Rezepte automatisch aktualisiert',
+    ]
+  },
+  {
+    date: '28.02.2026',
     title: 'Mobile Optimierung',
     changes: [
       'Der Rezepttitel erscheint in der Navigationsleiste, sobald er beim Scrollen nicht mehr sichtbar ist — auf der Anzeige- und der Bearbeitungsseite',

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -24,14 +24,26 @@
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, onUnmounted } from 'vue'
 import { useRecipeStore } from '@/stores/recipeStore'
 import RecipeCard from '@/components/RecipeCard.vue'
 
 const store = useRecipeStore()
 
+const onVisibilityChange = () => {
+  if (document.visibilityState === 'visible') {
+    store.invalidateRecipes()
+    store.fetchRecipes()
+  }
+}
+
 onMounted(() => {
   store.fetchRecipes()
+  document.addEventListener('visibilitychange', onVisibilityChange)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('visibilitychange', onVisibilityChange)
 })
 </script>
 


### PR DESCRIPTION
## Problem
Die Übersichtsseite lud alle Rezepte mit allen Daten auf einmal — inklusive aller Zutatentexte, Arbeitsschritte und Nährwerte, die auf der Karte gar nicht angezeigt werden. Pro Rezept wurden dabei 2 zusätzliche DB-Queries ausgeführt (N+1-Problem).

## Lösung

### Backend
- Neues `RecipeSummaryDto` mit nur den für die Karte benötigten Feldern: `id`, `title`, `description`, `imageUrl`, `prepTimeMinutes`, `baseServings`, `servingsTo`, `ingredientCount`
- `GET /api/recipes` gibt jetzt `List<RecipeSummaryDto>` zurück statt `List<Recipe>`
- `ingredientCount` wird per JPQL-Subquery direkt in der DB gezählt — kein Lazy-Loading, kein N+1

### Frontend
- `RecipeCard.vue`: `loading="lazy"` auf allen Karten-Bildern (Bilder werden erst geladen wenn sichtbar)
- `RecipeCard.vue`: Nutzt `ingredientCount` statt `ingredients.length`; "X Schritte" entfernt
- `recipeStore.js`: Cache Guard — kein Re-Fetch bei Navigation zwischen Seiten
- `HomeView.vue`: `visibilitychange`-Listener — Re-Fetch wenn App-Tab wieder aktiv wird (Multi-Client-Sync)
- `recipeStore.js`: `createRecipe`/`updateRecipe` normalisieren das Backend-Response via `toSummary()` damit der Store konsistent bleibt

## Ergebnis
- Statt `1 + 2N` DB-Queries: 1 Query für alle Rezepte
- Deutlich weniger übertragene Datenmenge pro Seitenaufruf
- Keine unnötigen Netzwerkanfragen bei Navigation
- Bilder werden lazy geladen

Closes #50