### PR TITLE
fix: Textareas bei gescannten Rezepten passen sich nicht an (#48)

### DIFF
--- a/frontend/src/components/RecipeForm.vue
+++ b/frontend/src/components/RecipeForm.vue
@@ -291,12 +291,12 @@ function autoResize(event) {
   el.style.height = el.scrollHeight + 'px'
 }
 
-function resizeAllTextareas() {
-  nextTick(() => {
-    document.querySelectorAll('.recipe-form textarea:not([readonly])').forEach(el => {
-      el.style.height = 'auto'
-      el.style.height = el.scrollHeight + 'px'
-    })
+async function resizeAllTextareas() {
+  await nextTick()
+  await nextTick()
+  document.querySelectorAll('.recipe-form textarea:not([readonly])').forEach(el => {
+    el.style.height = 'auto'
+    el.style.height = el.scrollHeight + 'px'
   })
 }
 
@@ -420,6 +420,7 @@ const handleScan = async () => {
 
     selectedImages.value.forEach(img => URL.revokeObjectURL(img.previewUrl))
     scanned.value = true
+    await resizeAllTextareas()
   } catch {
     scanError.value = 'Das Rezeptbild konnte nicht analysiert werden. Bitte versuche es erneut.'
   } finally {


### PR DESCRIPTION
## Problem

Bei gescannten Rezepten wurden die Textfelder (Beschreibung, Arbeitsschritte) nicht automatisch an die Höhe des Inhalts angepasst — sie blieben auf der Mindesthöhe von einer Zeile.

## Ursache

`resizeAllTextareas()` wird im `watch(() => props.recipe)` aufgerufen — also wenn ein bestehendes Rezept zum Bearbeiten geladen wird. Beim Scan hingegen befüllt `handleScan()` `formData` direkt, ohne dass sich `props.recipe` ändert. Deshalb wurde `resizeAllTextareas()` nach dem Scan nie aufgerufen.

Zusätzlich verwendete `resizeAllTextareas()` `nextTick()` als einfachen Callback — ein einzelner Render-Zyklus reicht aber nicht, wenn Vue nach dem Setzen eines neuen `instructions`-Arrays mehrere Zyklen zum Rendern der `v-for`-Textareas benötigt.

## Fix

- `resizeAllTextareas()` auf `async` umgebaut mit doppeltem `await nextTick()` (sicheres DOM-Update auch bei Array-Änderungen)
- In `handleScan()` nach `scanned.value = true` ein `await resizeAllTextareas()` ergänzt

Closes #48