### PR TITLE
fix: loremflickr-Fallback entfernen (Issue #55)

### DIFF
--- a/frontend/src/components/RecipeCard.vue
+++ b/frontend/src/components/RecipeCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="recipe-card" @click="navigateToDetail">
-    <div class="recipe-card__image">
-      <img :src="recipe.imageUrl || getFoodImage(recipe.id)" :alt="recipe.title" loading="lazy" />
+    <div v-if="recipe.imageUrl" class="recipe-card__image">
+      <img :src="recipe.imageUrl" :alt="recipe.title" loading="lazy" />
     </div>
     <div class="recipe-card__content">
       <h3 class="recipe-card__title">{{ recipe.title }}</h3>
@@ -30,7 +30,7 @@ const props = defineProps({
 
 const router = useRouter()
 
-const getFoodImage = (id) => `https://loremflickr.com/400/300/food?random=${id}`
+
 
 const formatPrepTime = (minutes) => {
   if (!minutes) return ''

--- a/frontend/src/data/changelog.js
+++ b/frontend/src/data/changelog.js
@@ -1,6 +1,13 @@
 export const changelog = [
   {
     date: '01.03.2026',
+    title: 'Schnellere Ladezeiten',
+    changes: [
+      'Rezepte ohne Bild laden jetzt schneller — externe Platzhalterbilder werden nicht mehr nachgeladen',
+    ]
+  },
+  {
+    date: '01.03.2026',
     title: 'Einladungslink',
     changes: [
       'Admins können in der Benutzerverwaltung einen Einladungslink generieren',

--- a/frontend/src/views/RecipeDetail.vue
+++ b/frontend/src/views/RecipeDetail.vue
@@ -9,8 +9,8 @@
         <h1 ref="titleRef">{{ recipe.title }}</h1>
       </header>
 
-      <div class="recipe-image">
-        <img :src="recipe.imageUrl || getFoodImage(recipe.id)" :alt="recipe.title" />
+      <div v-if="recipe.imageUrl" class="recipe-image">
+        <img :src="recipe.imageUrl" :alt="recipe.title" />
       </div>
 
       <p v-if="recipe.description" class="recipe-description">
@@ -130,7 +130,7 @@ const router = useRouter()
 const store = useRecipeStore()
 const uiStore = useUiStore()
 
-const getFoodImage = (id) => `https://loremflickr.com/800/400/food?random=${id}`
+
 
 const recipe = computed(() => store.currentRecipe)
 const currentServings = ref(1)


### PR DESCRIPTION
## Summary

- Rezepte ohne manuell gesetztes Bild zeigen kein Bild mehr an
- Externer Dienst `loremflickr.com` wird nicht mehr aufgerufen — keine unnötigen Netzwerkanfragen, keine Fehler, schnellere Ladezeiten
- Unsplash bleibt vollständig erhalten

## Änderungen

- `RecipeCard.vue`: `<img>` nur noch rendern wenn `recipe.imageUrl` vorhanden (`v-if`)
- `RecipeDetail.vue`: Bild-Block nur noch rendern wenn `recipe.imageUrl` vorhanden
- `getFoodImage()`-Funktion in beiden Dateien entfernt

Closes #55