### PR TITLE
Fix: Backend-Port 8080 nicht öffentlich exponieren

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,8 +82,9 @@ jobs:
                 hostname: backend
                 networks:
                   - recipebook_default
-                ports:
-                  - "8080:8080"
+                expose:
+                  - "8080"
+
                 environment:
                   SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/recipebook
                   SPRING_DATASOURCE_USERNAME: postgres


### PR DESCRIPTION
## Problem

Port 8080 des Backend-Containers war über `ports: ["8080:8080"]` öffentlich auf dem Host exponiert. Dadurch war Tomcat direkt von außen erreichbar — ohne TLS, ohne Nginx-Proxy.

## Änderung

`ports` durch `expose` ersetzt. Port 8080 ist jetzt nur noch intern im Docker-Netzwerk sichtbar. Nginx kann den Backend-Container weiterhin über `http://recipebook-backend:8080` erreichen, aber von außen ist der Port nicht mehr erreichbar.

## Auswirkung auf Nutzer

Keine — der normale Flow über `https://pastoors.cloud` funktioniert unverändert.