### PR TITLE
Gesamtanzahl Rezepte anzeigen (Issue #66)

### DIFF
--- a/frontend/src/data/changelog.js
+++ b/frontend/src/data/changelog.js
@@ -1,6 +1,14 @@
 export const changelog = [
   {
     date: '02.03.2026',
+    title: 'Rezeptanzahl',
+    changes: [
+      'Die Anzahl der Rezepte wird jetzt auf der Hauptseite angezeigt',
+      'Bei aktiver Suche wird angezeigt, wie viele Rezepte gefunden wurden',
+    ]
+  },
+  {
+    date: '02.03.2026',
     title: 'Ladeanimation',
     changes: [
       'Beim Speichern eines Rezepts und beim Analysieren eines Rezeptfotos erscheint jetzt eine Ladeanimation',

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -9,7 +9,12 @@
       <p v-else>Noch keine Rezepte vorhanden. Erstelle dein erstes Rezept!</p>
     </div>
 
-    <div v-else class="recipe-grid">
+    <div v-if="store.recipes.length > 0" class="recipe-count">
+      <span v-if="isFiltered">{{ store.filteredRecipes.length }} von {{ store.recipes.length }} Rezepten</span>
+      <span v-else>{{ store.recipes.length }} Rezepte</span>
+    </div>
+
+    <div class="recipe-grid">
       <RecipeCard
         v-for="recipe in store.filteredRecipes"
         :key="recipe.id"
@@ -21,11 +26,15 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
 import { useRecipeStore } from '@/stores/recipeStore'
 import RecipeCard from '@/components/RecipeCard.vue'
 
 const store = useRecipeStore()
+
+const isFiltered = computed(() =>
+  store.searchTerms.length > 0 && store.filteredRecipes.length < store.recipes.length
+)
 
 const onVisibilityChange = () => {
   if (document.visibilityState === 'visible') {
@@ -59,6 +68,12 @@ onUnmounted(() => {
 
 .error {
   color: var(--color-error, #e53e3e);
+}
+
+.recipe-count {
+  font-size: 0.875rem;
+  color: var(--color-text-muted, #a0aec0);
+  margin-bottom: 16px;
 }
 
 .recipe-grid {

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -74,6 +74,7 @@ onUnmounted(() => {
   font-size: 0.875rem;
   color: var(--color-text-muted, #a0aec0);
   margin-bottom: 16px;
+  text-align: center;
 }
 
 .recipe-grid {


### PR DESCRIPTION
## Zusammenfassung

Über dem Rezept-Grid wird die Gesamtanzahl der Rezepte angezeigt.

- Kein Filter aktiv: `43 Rezepte`
- Filter aktiv mit reduziertem Ergebnis: `12 von 43 Rezepten`
- Filter aktiv aber alle treffen zu: `43 Rezepte` (kein redundantes "43 von 43")

Closes #66