### PR TITLE
Nährwerte der Zutaten aus Rezept anzeigen (Issue #64)

### DIFF
--- a/backend/src/main/java/com/recipebook/service/NutritionService.java
+++ b/backend/src/main/java/com/recipebook/service/NutritionService.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 public class NutritionService {
 
   private static final Logger log = LoggerFactory.getLogger(NutritionService.class);
+  private static final Logger nutritionWarnLog = LoggerFactory.getLogger("NUTRITION_WARN");
 
   @Value("${openai.api-key:}")
   private String apiKey;
@@ -76,12 +77,27 @@ public class NutritionService {
 
     if (!missing.isEmpty() && apiKey != null && !apiKey.isBlank()) {
       List<IngredientCatalog> aiEntries = fetchFromOpenAi(missing);
+
       for (IngredientCatalog aiEntry : aiEntries) {
+        if (aiEntry.getNutritionKcal() == null && aiEntry.getNutritionFat() == null
+          && aiEntry.getNutritionProtein() == null && aiEntry.getNutritionCarbs() == null
+          && aiEntry.getNutritionFiber() == null) {
+          nutritionWarnLog.warn("Keine Nährwerte von OpenAI erhalten für: {} {}", aiEntry.getName(), aiEntry.getUnit());
+          continue;
+        }
+
         Ingredient matched = missing.stream()
           .filter(i -> i.getName().trim().equalsIgnoreCase(aiEntry.getName())
             && i.getUnit().trim().equalsIgnoreCase(aiEntry.getUnit()))
           .findFirst().orElse(null);
-        Double amount = matched != null ? parseAmount(matched.getAmount()) : null;
+
+        if (matched == null) {
+          nutritionWarnLog.warn("OpenAI hat unbekannte Zutat zurückgegeben (nicht in Eingabe): {} {}", aiEntry.getName(), aiEntry.getUnit());
+          saveToCatalog(aiEntry);
+          continue;
+        }
+
+        Double amount = parseAmount(matched.getAmount());
         if (amount == null) continue;
         if (aiEntry.getNutritionKcal() != null) { totalKcal += aiEntry.getNutritionKcal() * amount; hasAnyValue = true; }
         if (aiEntry.getNutritionFat() != null) { totalFat += aiEntry.getNutritionFat() * amount; hasAnyValue = true; }
@@ -89,6 +105,15 @@ public class NutritionService {
         if (aiEntry.getNutritionCarbs() != null) { totalCarbs += aiEntry.getNutritionCarbs() * amount; hasAnyValue = true; }
         if (aiEntry.getNutritionFiber() != null) { totalFiber += aiEntry.getNutritionFiber() * amount; hasAnyValue = true; }
         saveToCatalog(aiEntry);
+      }
+
+      List<String> returnedNames = aiEntries.stream()
+        .map(e -> e.getName().trim().toLowerCase())
+        .toList();
+      for (Ingredient m : missing) {
+        if (!returnedNames.contains(m.getName().trim().toLowerCase())) {
+          nutritionWarnLog.warn("OpenAI hat keine Antwort für Zutat geliefert: {} {}", m.getName(), m.getUnit());
+        }
       }
     }
 
@@ -107,6 +132,7 @@ public class NutritionService {
         Antworte NUR mit einem validen JSON-Array ohne Markdown-Codeblock:
         [{"name": "Mehl", "unit": "g", "kcal": 3.4, "fat": 0.01, "protein": 0.1, "carbs": 0.72, "fiber": 0.03}]
         Alle Werte pro 1 Einheit (nicht pro Gesamtmenge), in Gramm außer kcal.
+        Wichtig: Verwende für "name" EXAKT denselben Namen wie in der Eingabe. Keine Änderung der Schreibweise, kein Singular/Plural, keine Übersetzung.
         Zutaten: %s
         """.formatted(ingredientList);
 

--- a/backend/src/main/java/com/recipebook/service/NutritionService.java
+++ b/backend/src/main/java/com/recipebook/service/NutritionService.java
@@ -124,15 +124,15 @@ public class NutritionService {
   private List<IngredientCatalog> fetchFromOpenAi(List<Ingredient> ingredients) {
     try {
       String ingredientList = ingredients.stream()
-        .map(i -> i.getAmount() + " " + i.getUnit() + " " + i.getName())
-        .collect(Collectors.joining(", "));
+        .map(i -> "{\"name\": \"" + i.getName() + "\", \"amount\": \"" + i.getAmount() + "\", \"unit\": \"" + i.getUnit() + "\"}")
+        .collect(Collectors.joining(", ", "[", "]"));
 
       String prompt = """
         Gib die Nährwerte pro 1 Einheit für jede der folgenden Zutaten zurück.
         Antworte NUR mit einem validen JSON-Array ohne Markdown-Codeblock:
         [{"name": "Mehl", "unit": "g", "kcal": 3.4, "fat": 0.01, "protein": 0.1, "carbs": 0.72, "fiber": 0.03}]
         Alle Werte pro 1 Einheit (nicht pro Gesamtmenge), in Gramm außer kcal.
-        Wichtig: Verwende für "name" EXAKT denselben Namen wie in der Eingabe. Keine Änderung der Schreibweise, kein Singular/Plural, keine Übersetzung.
+        Wichtig: Verwende für "name" und "unit" EXAKT die Werte aus der Eingabe. Keine Änderung der Schreibweise, kein Singular/Plural, keine Übersetzung.
         Zutaten: %s
         """.formatted(ingredientList);
 

--- a/backend/src/main/java/com/recipebook/service/NutritionService.java
+++ b/backend/src/main/java/com/recipebook/service/NutritionService.java
@@ -86,6 +86,16 @@ public class NutritionService {
           continue;
         }
 
+        boolean allZero = isZeroOrNull(aiEntry.getNutritionKcal())
+          && isZeroOrNull(aiEntry.getNutritionFat())
+          && isZeroOrNull(aiEntry.getNutritionProtein())
+          && isZeroOrNull(aiEntry.getNutritionCarbs())
+          && isZeroOrNull(aiEntry.getNutritionFiber());
+        if (allZero) {
+          nutritionWarnLog.warn("OpenAI hat nur Nullwerte zurückgegeben für: {} {}", aiEntry.getName(), aiEntry.getUnit());
+          continue;
+        }
+
         Ingredient matched = missing.stream()
           .filter(i -> i.getName().trim().equalsIgnoreCase(aiEntry.getName())
             && i.getUnit().trim().equalsIgnoreCase(aiEntry.getUnit()))
@@ -197,6 +207,10 @@ public class NutritionService {
     } catch (Exception e) {
       log.warn("Could not save ingredient to catalog: {} {}: {}", entry.getName(), entry.getUnit(), e.getMessage());
     }
+  }
+
+  private boolean isZeroOrNull(Double value) {
+    return value == null || value == 0.0;
   }
 
   private Double parseAmount(String amount) {

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+  <property name="LOG_PATH" value="${LOG_PATH:-logs}"/>
+
+  <appender name="NUTRITION_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_PATH}/nutrition-warnings.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_PATH}/nutrition-warnings.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="NUTRITION_WARN" level="WARN" additivity="false">
+    <appender-ref ref="NUTRITION_FILE"/>
+  </logger>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</configuration>

--- a/frontend/src/data/changelog.js
+++ b/frontend/src/data/changelog.js
@@ -1,6 +1,13 @@
 export const changelog = [
   {
     date: '02.03.2026',
+    title: 'Nährwerte der Zutaten',
+    changes: [
+      'Im Nährwerte-Tab eines Rezepts gibt es jetzt einen Link zur Zutatenseite — dort werden alle Zutaten des Rezepts mit ihren Nährwerten angezeigt, sortiert nach Kalorien',
+    ]
+  },
+  {
+    date: '02.03.2026',
     title: 'Ladeanimation',
     changes: [
       'Beim Speichern eines Rezepts und beim Analysieren eines Rezeptfotos erscheint jetzt eine Ladeanimation',

--- a/frontend/src/data/changelog.js
+++ b/frontend/src/data/changelog.js
@@ -1,6 +1,14 @@
 export const changelog = [
   {
     date: '02.03.2026',
+    title: 'Zuverlässigere Nährwertberechnung',
+    changes: [
+      'Die Nährwertberechnung erkennt Zutaten jetzt zuverlässiger — auch wenn die KI intern nach einer anderen Schreibweise sucht',
+      'Zutaten, für die keine Nährwerte ermittelt werden konnten, werden nun protokolliert',
+    ]
+  },
+  {
+    date: '02.03.2026',
     title: 'Nährwerte der Zutaten',
     changes: [
       'Im Nährwerte-Tab eines Rezepts gibt es jetzt einen Link zur Zutatenseite — dort werden alle Zutaten des Rezepts mit ihren Nährwerten angezeigt, sortiert nach Kalorien',

--- a/frontend/src/views/IngredientsView.vue
+++ b/frontend/src/views/IngredientsView.vue
@@ -9,49 +9,50 @@
     <div v-else-if="error" class="error-banner">{{ error }}</div>
     <div v-else-if="entries.length === 0" class="empty">Noch keine Zutaten im Katalog.</div>
 
-    <table v-else class="ingredients-table">
-      <thead>
-        <tr>
-          <th @click="setSort('name')" class="sortable">
-            Name <span class="sort-indicator">{{ sortIndicator('name') }}</span>
-          </th>
-          <th @click="setSort('unit')" class="sortable">
-            Einheit <span class="sort-indicator">{{ sortIndicator('unit') }}</span>
-          </th>
-          <th @click="setSort('nutritionKcal')" class="sortable">
-            kcal <span class="sort-indicator">{{ sortIndicator('nutritionKcal') }}</span>
-          </th>
-          <th @click="setSort('nutritionFat')" class="sortable">
-            Fett (g) <span class="sort-indicator">{{ sortIndicator('nutritionFat') }}</span>
-          </th>
-          <th @click="setSort('nutritionProtein')" class="sortable">
-            Protein (g) <span class="sort-indicator">{{ sortIndicator('nutritionProtein') }}</span>
-          </th>
-          <th @click="setSort('nutritionCarbs')" class="sortable">
-            KH (g) <span class="sort-indicator">{{ sortIndicator('nutritionCarbs') }}</span>
-          </th>
-          <th @click="setSort('nutritionFiber')" class="sortable">
-            Ballaststoffe (g) <span class="sort-indicator">{{ sortIndicator('nutritionFiber') }}</span>
-          </th>
-          <th v-if="isAdmin"></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="entry in sortedEntries" :key="entry.id" @click="openDetailModal(entry)" class="clickable-row">
-          <td>{{ entry.name }}</td>
-          <td>{{ entry.unit || '—' }}</td>
-          <td>{{ fmt(entry.nutritionKcal) }}</td>
-          <td>{{ fmt(entry.nutritionFat) }}</td>
-          <td>{{ fmt(entry.nutritionProtein) }}</td>
-          <td>{{ fmt(entry.nutritionCarbs) }}</td>
-          <td>{{ fmt(entry.nutritionFiber) }}</td>
-          <td v-if="isAdmin" class="actions-cell" @click.stop>
-            <button @click="openEditModal(entry)" class="btn-edit">Bearbeiten</button>
-            <button @click="openDeleteConfirm(entry)" class="btn-delete">Löschen</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-else>
+      <div v-for="group in groupedEntries" :key="group.unit" class="unit-group">
+        <h2 class="unit-heading">{{ group.unit || '—' }}</h2>
+        <table class="ingredients-table">
+          <thead>
+            <tr>
+              <th @click="setSort('name')" class="sortable">
+                Name <span class="sort-indicator">{{ sortIndicator('name') }}</span>
+              </th>
+              <th @click="setSort('nutritionKcal')" class="sortable">
+                kcal <span class="sort-indicator">{{ sortIndicator('nutritionKcal') }}</span>
+              </th>
+              <th @click="setSort('nutritionFat')" class="sortable">
+                Fett (g) <span class="sort-indicator">{{ sortIndicator('nutritionFat') }}</span>
+              </th>
+              <th @click="setSort('nutritionProtein')" class="sortable">
+                Protein (g) <span class="sort-indicator">{{ sortIndicator('nutritionProtein') }}</span>
+              </th>
+              <th @click="setSort('nutritionCarbs')" class="sortable">
+                KH (g) <span class="sort-indicator">{{ sortIndicator('nutritionCarbs') }}</span>
+              </th>
+              <th @click="setSort('nutritionFiber')" class="sortable">
+                Ballaststoffe (g) <span class="sort-indicator">{{ sortIndicator('nutritionFiber') }}</span>
+              </th>
+              <th v-if="isAdmin"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="entry in group.entries" :key="entry.id" @click="openDetailModal(entry)" class="clickable-row">
+              <td>{{ entry.name }}</td>
+              <td>{{ fmt(entry.nutritionKcal) }}</td>
+              <td>{{ fmt(entry.nutritionFat) }}</td>
+              <td>{{ fmt(entry.nutritionProtein) }}</td>
+              <td>{{ fmt(entry.nutritionCarbs) }}</td>
+              <td>{{ fmt(entry.nutritionFiber) }}</td>
+              <td v-if="isAdmin" class="actions-cell" @click.stop>
+                <button @click="openEditModal(entry)" class="btn-edit">Bearbeiten</button>
+                <button @click="openDeleteConfirm(entry)" class="btn-delete">Löschen</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
 
     <div v-if="selectedEntry" class="modal-overlay" @click.self="closeDetailModal">
       <div class="modal-content">
@@ -233,14 +234,14 @@ async function load() {
   }
 }
 
-const sortedEntries = computed(() => {
+const groupedEntries = computed(() => {
   let result = [...entries.value]
   if (activeFilter.value) {
     result = result.filter(e =>
       activeFilter.value.includes(`${e.name}|${e.unit}`.toLowerCase())
     )
   }
-  return result.sort((a, b) => {
+  result.sort((a, b) => {
     const av = a[sortKey.value]
     const bv = b[sortKey.value]
     if (av == null && bv == null) return 0
@@ -253,6 +254,15 @@ const sortedEntries = computed(() => {
     }
     return sortDir.value === 'asc' ? av - bv : bv - av
   })
+  const map = new Map()
+  for (const entry of result) {
+    const unit = entry.unit || ''
+    if (!map.has(unit)) map.set(unit, [])
+    map.get(unit).push(entry)
+  }
+  return [...map.entries()]
+    .sort(([a], [b]) => a.localeCompare(b, 'de'))
+    .map(([unit, entries]) => ({ unit, entries }))
 })
 
 function setSort(key) {
@@ -424,6 +434,19 @@ async function openDeleteConfirm(entry) {
   padding: 10px;
   border-radius: 4px;
   margin-bottom: 12px;
+}
+
+.unit-group {
+  margin-bottom: 32px;
+}
+
+.unit-heading {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #4a5568;
+  margin: 0 0 8px 0;
+  padding-bottom: 6px;
+  border-bottom: 2px solid #e2e8f0;
 }
 
 .ingredients-table {

--- a/frontend/src/views/IngredientsView.vue
+++ b/frontend/src/views/IngredientsView.vue
@@ -182,9 +182,11 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'
 import { ingredientCatalogService } from '@/services/ingredientCatalogService'
 
+const route = useRoute()
 const authStore = useAuthStore()
 const isAdmin = computed(() => authStore.isAdmin)
 
@@ -196,6 +198,7 @@ const modalError = ref(null)
 
 const sortKey = ref('name')
 const sortDir = ref('asc')
+const activeFilter = ref(null)
 
 const selectedEntry = ref(null)
 
@@ -210,6 +213,11 @@ function emptyForm() {
 }
 
 onMounted(async () => {
+  if (route.query.sort) sortKey.value = route.query.sort
+  if (route.query.dir) sortDir.value = route.query.dir
+  if (route.query.filter) {
+    activeFilter.value = route.query.filter.split(',').map(s => s.toLowerCase())
+  }
   await load()
 })
 
@@ -226,7 +234,13 @@ async function load() {
 }
 
 const sortedEntries = computed(() => {
-  return [...entries.value].sort((a, b) => {
+  let result = [...entries.value]
+  if (activeFilter.value) {
+    result = result.filter(e =>
+      activeFilter.value.includes(`${e.name}|${e.unit}`.toLowerCase())
+    )
+  }
+  return result.sort((a, b) => {
     const av = a[sortKey.value]
     const bv = b[sortKey.value]
     if (av == null && bv == null) return 0

--- a/frontend/src/views/RecipeDetail.vue
+++ b/frontend/src/views/RecipeDetail.vue
@@ -92,6 +92,12 @@
             </tr>
           </tbody>
         </table>
+
+        <div v-if="activeTab === 'nutrition'" class="nutrition-link">
+          <button @click="goToIngredients" class="btn-nutrition-link">
+            Nährwerte der Zutaten anzeigen
+          </button>
+        </div>
       </section>
 
       <section v-if="recipe.instructions?.length" class="recipe-section">
@@ -205,6 +211,14 @@ const scaledIngredients = computed(() => {
 const formatNutrition = (value) => {
   if (value == null) return '–'
   return Math.round(value * 10) / 10
+}
+
+const goToIngredients = () => {
+  const filter = (recipe.value.ingredients || [])
+    .filter(i => i.name && i.unit)
+    .map(i => `${i.name}|${i.unit}`)
+    .join(',')
+  router.push({ name: 'ingredients', query: { filter, sort: 'nutritionKcal', dir: 'desc' } })
 }
 
 const formatPrepTime = (minutes) => {
@@ -560,5 +574,25 @@ const handleDelete = async () => {
 
 .nutrition-table tr:last-child td {
   border-bottom: none;
+}
+
+.nutrition-link {
+  margin-top: 16px;
+  text-align: right;
+}
+
+.btn-nutrition-link {
+  background: none;
+  border: none;
+  color: var(--color-primary, #4a5568);
+  font-size: 0.875rem;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.btn-nutrition-link:hover {
+  color: var(--color-primary-dark, #2d3748);
 }
 </style>


### PR DESCRIPTION
## Zusammenfassung

Im Nährwerte-Tab der Rezeptdetailseite erscheint jetzt ein Link "Nährwerte der Zutaten anzeigen". Dieser führt zur Zutatenseite, vorgefiltert auf die Zutaten des Rezepts und absteigend nach kcal sortiert.

## Änderungen

- **`RecipeDetail.vue`** — Button unter der Nährwerttabelle, `goToIngredients()` baut URL-Query aus Rezeptzutaten (`name|unit`-Paare)
- **`IngredientsView.vue`** — liest beim Mount `route.query` (sort, dir, filter) und wendet Filter auf `sortedEntries` an

Closes #64